### PR TITLE
Add ubuntu-musl for ldc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,13 @@ export D_VERSION=dmd
 build:
 	$(MAKE) -C circleci build
 	$(MAKE) -C ubuntu build
+	$(MAKE) -C ubuntu-musl build
 	#$(MAKE) -C alpine build
 
 push:
 	$(MAKE) -C circleci push
 	$(MAKE) -C ubuntu push
+	$(MAKE) -C ubuntu-musl push
 	#$(MAKE) -C alpine push
 
 test:

--- a/ubuntu-musl/Makefile
+++ b/ubuntu-musl/Makefile
@@ -1,0 +1,17 @@
+BASE_IMAGE="ubuntu:18.04"
+DOCKER_POSTFIX=-ubuntu-musl
+
+ifeq ($(D_VERSION),ldc)
+ include ../common.mak
+
+ Dockerfile: ../ubuntu/dlang.docker ldc-musl.docker
+	cat $+ | \
+		sed "s|{{D_VERSION}}|${D_VERSION_RESOLVED}|g" | \
+		sed "s|{{BASE_IMAGE}}|${BASE_IMAGE}|g" | \
+		sed "s|{{BIN_FOLDER}}|${BIN_FOLDER}|g" | \
+		sed "s|{{LIB_FOLDER}}|${LIB_FOLDER}|g" \
+		> $@
+else
+ build:
+ push:
+endif

--- a/ubuntu-musl/ldc-musl.conf
+++ b/ubuntu-musl/ldc-musl.conf
@@ -1,11 +1,10 @@
-default:
+x86_64-alpine-linux-musl:
 {
     // default switches injected before all explicit command-line switches
     switches = [
         "-defaultlib=phobos2-ldc,druntime-ldc",
         "-L--no-warn-search-mismatch",
         "-gcc=musl-gcc",
-        "-mtriple=x86_64-alpine-linux-musl",
         "-static"
     ];
     // default switches appended after all explicit command-line switches

--- a/ubuntu-musl/ldc-musl.conf
+++ b/ubuntu-musl/ldc-musl.conf
@@ -1,0 +1,20 @@
+default:
+{
+    // default switches injected before all explicit command-line switches
+    switches = [
+        "-defaultlib=phobos2-ldc,druntime-ldc",
+        "-L--no-warn-search-mismatch",
+        "-gcc=musl-gcc",
+        "-mtriple=x86_64-alpine-linux-musl",
+        "-static"
+    ];
+    // default switches appended after all explicit command-line switches
+    post-switches = [
+        "-I%%ldcbinarypath%%/../import",
+    ];
+    // default directories to be searched for libraries when linking
+    lib-dirs = [
+        "%%ldcbinarypath%%/../lib-musl"
+    ];
+};
+

--- a/ubuntu-musl/ldc-musl.docker
+++ b/ubuntu-musl/ldc-musl.docker
@@ -4,4 +4,8 @@ RUN apt-get install -y --no-install-recommends cmake musl-tools && \
     ldc-build-runtime --dFlags="-w;-mtriple=x86_64-alpine-linux-musl" BUILD_SHARED_LIBS=OFF && \
     mv /ldc-build-runtime.tmp/lib /dlang/dc/lib-musl && \
     rm -rf /ldc-build-runtime.tmp
-COPY ldc-musl.conf /dlang/dc/etc/ldc2.conf
+COPY ldc-musl.conf /dlang/dc/etc/ldc2.conf.2
+WORKDIR /dlang/dc/etc
+RUN cat ldc2.conf ldc2.conf.2 > ldc2.conf_ && \
+    mv ldc2.conf_ ldc2.conf && rm ldc2.conf.2
+WORKDIR /

--- a/ubuntu-musl/ldc-musl.docker
+++ b/ubuntu-musl/ldc-musl.docker
@@ -4,8 +4,6 @@ RUN apt-get install -y --no-install-recommends cmake musl-tools && \
     ldc-build-runtime --dFlags="-w;-mtriple=x86_64-alpine-linux-musl" BUILD_SHARED_LIBS=OFF && \
     mv /ldc-build-runtime.tmp/lib /dlang/dc/lib-musl && \
     rm -rf /ldc-build-runtime.tmp
-COPY ldc-musl.conf /dlang/dc/etc/ldc2.conf.2
-WORKDIR /dlang/dc/etc
-RUN cat ldc2.conf ldc2.conf.2 > ldc2.conf_ && \
-    mv ldc2.conf_ ldc2.conf && rm ldc2.conf.2
-WORKDIR /
+COPY ldc-musl.conf /ldc2.conf.musl
+RUN cat /ldc2.conf.musl >> /dlang/dc/etc/ldc2.conf && \
+    rm ldc2.conf.musl

--- a/ubuntu-musl/ldc-musl.docker
+++ b/ubuntu-musl/ldc-musl.docker
@@ -1,0 +1,7 @@
+ARG CC=musl-gcc
+
+RUN apt-get install -y --no-install-recommends cmake musl-tools && \
+    ldc-build-runtime --dFlags="-w;-mtriple=x86_64-alpine-linux-musl" BUILD_SHARED_LIBS=OFF && \
+    mv /ldc-build-runtime.tmp/lib /dlang/dc/lib-musl && \
+    rm -rf /ldc-build-runtime.tmp
+COPY ldc-musl.conf /dlang/dc/etc/ldc2.conf


### PR DESCRIPTION
This PR is to solve #2 partially by providing a way to build a single binary with dlang.

Preparing host compilers for Alpine Linux (i.e. with musl libc) is time consuming task because dmd, gdc and ldc do not provide a binary for it.

Instead of that, this request provides a way to build an ubuntu image with a cross compiler for musl libc.
It enables us to build a single binary with dlang and I guess it covers most use cases that use Alpine Linux.
This request only adds `ldc-ubuntu-musl` image because ldc provides [`ldc-build-runtime`](https://wiki.dlang.org/Building_LDC_runtime_libraries) that easily builds runtime libraries for other architecture but other compilers do not.

`ldc-ubuntu-musl` image is built based on the dockerfile for `ldc-ubuntu`.
~~It sets `-mtriple=x86_64-alpine-linux-musl` and `-static` by default.~~
Sorry, I found that `rdmd` does not work if these options are the default setting.
```console
root@da690b9721ba:/# echo 'import std; void main() { writeln("Hello!"); }' > sample.d
root@da690b9721ba:/# ldc2 -unittest -run sample.d # ldc2 works
Hello!
root@da690b9721ba:/# rdmd -unittest sample.d # but rdmd does not work
Aborted
```

To make less confusion, I make them as an option.

```console
root@6de061b342bc:/# echo 'import std; void main() { writeln("Hello!"); }' > sample.d
root@6de061b342bc:/# ldc2 sample.d # compile with x86_64-unknown-linux-gnu by default
root@6de061b342bc:/# ldd sample
        linux-vdso.so.1 (0x00007fff4f1fe000)
        librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x00007fca5efd0000)
        libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007fca5edcc000)
        libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007fca5ebad000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007fca5e80f000)
        libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007fca5e5f7000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007fca5e206000)
        /lib64/ld-linux-x86-64.so.2 (0x00007fca5f1d8000)
root@6de061b342bc:/# ldc2 -mtriple=x86_64-alpine-linux-musl -static sample.d # specify to build a statically-linked binary with musl libc
root@6de061b342bc:/# ldd sample
        not a dynamic executable
```



Limitations:
- `std.net.curl` does not work because libcurl (installed via apt) is build with glibc
- It only supports `-static` (it is provided in the default settings) because I failed to prepare dynamic link libraries with musl libc(See [a thread in gitter chat of ldc](https://gitter.im/ldc-developers/main?at=5d81d338577fc14c7fe553a1))