### PR TITLE
Add user dlang to ubuntu docker

### DIFF
--- a/ubuntu/dlang.docker
+++ b/ubuntu/dlang.docker
@@ -23,8 +23,18 @@ RUN set -ex && \
 	&& update-alternatives --install "/usr/bin/ld" "ld" "/usr/bin/ld.gold" 20 \
 	&& update-alternatives --install "/usr/bin/ld" "ld" "/usr/bin/ld.bfd" 10
 
+RUN groupadd --gid 1000 dlang \
+  && useradd --uid 1000 --gid dlang --shell /bin/bash --create-home dlang
+
+RUN mkdir ${DPATH}\
+    && chown dlang ${DPATH}
+
+USER dlang
+
 RUN set -ex && \
 	curl -fsS https://dlang.org/install.sh | bash -s ${D_VERSION} -p ${DPATH}
+
+USER root
 
 RUN chmod 755 -R ${DPATH}
 RUN ln -s ${DPATH}/${D_VERSION} ${DPATH}/dc && ls ${DPATH}


### PR DESCRIPTION
By executing the docker container with a non root user, security risks are mitigated and technical issues are avoided (like non deletable files on Jenkins workspace due to root permissions).

This pr adds an user `dlang` which is owner of folder `/dlang`. By default, still the user root is used by starting a container of this image.