### PR TITLE
Add Alpine Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ export D_VERSION=dmd
 build:
 	$(MAKE) -C circleci build
 	$(MAKE) -C ubuntu build
-	#$(MAKE) -C alpine build
+	$(MAKE) -C alpine build
 	$(MAKE) -C amazonlinux build
 	$(MAKE) -C amazonlinux clean
 	$(MAKE) -C amazonlinux build DOCKER_POSTFIX=-amazonlinux2 BASE_IMAGE=amazonlinux:2
@@ -13,7 +13,7 @@ build:
 push:
 	$(MAKE) -C circleci push
 	$(MAKE) -C ubuntu push
-	#$(MAKE) -C alpine push
+	$(MAKE) -C alpine push
 	$(MAKE) -C amazonlinux push
 	$(MAKE) -C amazonlinux push DOCKER_POSTFIX=-amazonlinux2
 

--- a/alpine/Makefile
+++ b/alpine/Makefile
@@ -1,12 +1,47 @@
-BASE_IMAGE="alpine:3.7"
+BASE_IMAGE="alpine:3.12"
 DOCKER_POSTFIX=-alpine
 
-include ../common.mak
+################################################################################
+# Global variables
+################################################################################
+DOCKER_ORG=dlang2
+D_VERSION=dmd
+
+################################################################################
+# Automatically set variables
+################################################################################
+# D_VERSION_RESOLVED does not work due to different release cycle in Alpine Linux
+# The canonical name of the resolved tag
+D_VERSION_RESOLVED_ALPINE=$(shell docker run -t -e D_VERSION=${D_VERSION} -v $(CURDIR):/workdir ${BASE_IMAGE} /workdir/show_resolved_version.sh)
+
+D_COMPILER=$(firstword $(subst -, ,$(D_VERSION)))
+DOCKER_IMAGE_BASE=$(D_COMPILER)$(DOCKER_POSTFIX)
+
+# Nothing to be done for non-stable versions, e.g. dmd-nightly
+ifneq (,$(findstring $(D_COMPILER)-,$(D_VERSION)))
+build:
+push:
+
+else
+ DOCKER_IMAGE_NAME=$(DOCKER_IMAGE_BASE):latest
+ # The canonical name, e.g. dmd:2.077.1
+ DOCKER_IMAGE_NAME_RESOLVED=$(DOCKER_IMAGE_BASE):$(subst $(D_COMPILER)-,,$(D_VERSION_RESOLVED_ALPINE))
+ # LDC is installed as ldc2
+ D_COMPILER_EXEC=$(subst ldc,ldc2,$(D_COMPILER))
+ PKG_NAME=$(subst gdc,gdmd,$(D_COMPILER))
 
 Dockerfile: dlang.docker Makefile
 	cat $< | \
-		sed "s|{{D_VERSION}}|${D_VERSION_RESOLVED}|g" | \
 		sed "s|{{BASE_IMAGE}}|${BASE_IMAGE}|g" | \
-		sed "s|{{BIN_FOLDER}}|${BIN_FOLDER}|g" | \
-		sed "s|{{LIB_FOLDER}}|${LIB_FOLDER}|g" \
+		sed "s|{{PKG_NAME}}|${PKG_NAME}|g" \
 		> $@
+
+build: Dockerfile
+	docker build -t $(DOCKER_ORG)/$(DOCKER_IMAGE_NAME) .
+	docker build -t $(DOCKER_ORG)/$(DOCKER_IMAGE_NAME_RESOLVED) .
+	docker run --rm -i -t $(DOCKER_ORG)/$(DOCKER_IMAGE_NAME_RESOLVED) ${D_COMPILER_EXEC} --version | grep -i "${D_COMPILER}"
+
+push: build
+	docker push $(DOCKER_ORG)/$(DOCKER_IMAGE_NAME)
+	docker push $(DOCKER_ORG)/$(DOCKER_IMAGE_NAME_RESOLVED)
+endif

--- a/alpine/dlang.docker
+++ b/alpine/dlang.docker
@@ -1,38 +1,8 @@
 FROM {{BASE_IMAGE}}
 
-ENV D_VERSION {{D_VERSION}}
-ENV BIN_FOLDER {{BIN_FOLDER}}
-ENV LIB_FOLDER {{LIB_FOLDER}}
-ENV DEBIAN_FRONTEND=noninteractive
-ENV DPATH=/dlang
-
-RUN set -eux; \
-	apk add --no-cache \
-	bash \
-	binutils-gold \
-	ca-certificates \
-	curl \
+RUN apk add --no-cache \
+	dub \
+	dtools-rdmd \
 	gcc \
-	g++ \
-	libstdc++ \
-	gnupg \
-	libevent-dev \
-	make \
-	openssl-dev \
-	xz
-
-RUN wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://raw.githubusercontent.com/sgerrand/alpine-pkg-glibc/master/sgerrand.rsa.pub && \
-wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.26-r0/glibc-2.26-r0.apk && \
-	apk add glibc-2.26-r0.apk && \
-	rm glibc-2.26-r0.apk /etc/apk/keys/sgerrand.rsa.pub
-
-RUN ln -s /usr/bin/ld.gold /usr/local/bin/ld
-
-RUN set -ex && \
-	curl -fsS https://dlang.org/install.sh | bash -s ${D_VERSION} -p ${DPATH}
-
-ENV PATH="${DPATH}/${D_VERSION}/${BIN_FOLDER}:${PATH}"
-ENV LIBRARY_PATH="${DPATH}/${D_VERSION}/${LIB_FOLDER}:${LIBRARY_PATH}"
-ENV LD_LIBRARY_PATH="${DPATH}/${D_VERSION}/${LIB_FOLDER}:${LD_LIBRARY_PATH}"
-RUN chmod 755 -R ${DPATH}
-RUN echo "${DPATH}/${D_VERSION}/activate" >> /etc/profile
+	musl-dev \
+	{{PKG_NAME}}

--- a/alpine/show_resolved_version.sh
+++ b/alpine/show_resolved_version.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+if [ "$D_VERSION" = "gdc" ]; then
+    pkg=$(apk --no-cache info gcc-gdc | grep 'description:$' | awk '{ print $1 };')
+    pkg=${pkg%-*}
+    echo ${pkg#*-}
+else
+    pkg=$(apk --no-cache info $D_VERSION | grep 'description:$' | awk '{ print $1 };')
+    echo ${pkg%-*}
+fi


### PR DESCRIPTION
This request fixes #2.

It build alpine images for dmd, ldc, and gdc.
It does nothing for non-stable versions (e.g., dmd-beta, ldc-beta).

I confirmed that the following commands work in the resulted images as intended.

For dmd:
```console
$ dmd sample.d; ./sample
$ rdmd --compiler=dmd sample.d
$ dub init foo; cd foo; dub run # Note: initialize the directory with default options
```

For ldc:
```console
$ ldc2 sample.d; ./sample
$ ldc2 sample.d -static; ./sample # for static linked binary
$ rdmd sample.d
$ dub init foo; cd foo; dub run
```

For gdc:
```console
$ gdc sample.d -o sample; ./sample
$ gdc sample.d -o sample -static; ./sample # for static linked binary
$ rdmd --compiler=gdmd sample.d # Note: it prints annoying log messages but solving it is out of scope of this request
$ dub init foo; cd foo; dub run
```

sample.d (used in the above examples):
```d
import std.stdio;

void main()
{
    writeln("hello");
}
```


Note:
It uses the official packages provided by Alpine Linux instead of using packages by dlang.org as used in other Linux distributions.
Therefore it cannot use `D_VERSION_RESOLVED` because Alpine Linux has different release cycles for D compilers.
Instead of that, it introduces `D_VERSION_RESOLVED_ALPINE` that specifies the latest official package version without package revision number (See "show_resolved_version.sh" for details).
